### PR TITLE
Add Docker container workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,5 +13,4 @@ jobs:
       - name: Upload artifact
         uses: actions/upload-artifact@v2
         with:
-          name: page
           path: figure1

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,4 +13,5 @@ jobs:
       - name: Upload artifact
         uses: actions/upload-artifact@v2
         with:
+          name: figures
           path: figure1

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,17 @@
+name: Build
+on: [push]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    container:
+      image: lennartwittkuhn/replaysim-wittkuhn-etal2021
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Install and Build
+        run: make all
+      - name: Upload artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: page
+          path: figure1

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,17 @@
+FROM r-base:4.0.3
+
+RUN apt-get update
+
+RUN echo 'APT::Get::Install-Recommends "false";' >> /etc/apt/apt.conf
+RUN echo 'options(Ncpus=4, repos=structure(c(CRAN="https://cloud.r-project.org")))' > ~/.Rprofile
+RUN echo 'installOrQuit <- function(p) {tryCatch(install.packages(p), warning=function(e){q(status=1)})}' >> ~/.Rprofile
+
+# external dependencies
+#RUN apt-get install -y pandoc pandoc-citeproc && apt-get clean
+
+# prefer binary R packages, if they are available
+RUN apt-get install -y \
+r-cran-viridis
+
+# add missing source packages in blocks of 4
+#RUN Rscript -e "installOrQuit(c('assertr', 'pacman', 'here', 'lme4'))"

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,4 @@
+all: figure1/fig1c_numsteps.pdf
+
+figure1/fig1c_numsteps.pdf: replay_sim.R make_transitionmat.R gen_functions.R
+	Rscript replay_sim.R

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Replay Simulations
 
-![main workflow](https://github.com/nschuck/replaysim-wittkuhn-etal2021/actions/workflows/main.yml/badge.svg)
+[![Build](https://github.com/nschuck/replaysim-wittkuhn-etal2021/actions/workflows/main.yml/badge.svg)](https://github.com/nschuck/replaysim-wittkuhn-etal2021/actions/workflows/main.yml)
 
 Code for Review illustration in Wittkuhn, Chien, McMaster, Schuck
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Replay Simulations
 
+![main workflow](https://github.com/nschuck/replaysim-wittkuhn-etal2021/actions/workflows/main.yml/badge.svg)
+
 Code for Review illustration in Wittkuhn, Chien, McMaster, Schuck
 
 ## Citation

--- a/README.md
+++ b/README.md
@@ -14,11 +14,28 @@ Wittkuhn, L., Chien, S., Hall-McMaster, S., and Schuck, N. W. (2021). *Replay in
 
 ### Make
 
+You can also run the code using `make` by running the following command.
+
 ```bash
 make all
 ```
 
 ### Docker
+
+We've created a Docker container (see [Dockerfile](Dockerfile)) and [uploaded it](https://hub.docker.com/r/lennartwittkuhn/replaysim-wittkuhn-etal2021) to dockerhub.
+
+#### Running the container
+
+You can run the `make` command inside the Docker container:
+
+```bash
+docker run --rm -v $PWD:/home lennartwittkuhn/replaysim-wittkuhn-etal2021 /bin/sh -c "cd /home; make all"
+```
+
+#### Building the container
+
+The commands below were used by us to create the container.
+They are listed here for documentation purposes.
 
 ```bash
 docker login
@@ -30,8 +47,4 @@ docker build -t lennartwittkuhn/replaysim-wittkuhn-etal2021:latest .
 
 ```bash
 docker push lennartwittkuhn/replaysim-wittkuhn-etal2021:latest
-```
-
-```bash
-docker run --rm -v $PWD:/home lennartwittkuhn/replaysim-wittkuhn-etal2021 /bin/sh -c "cd /home; make all"
 ```

--- a/README.md
+++ b/README.md
@@ -32,6 +32,9 @@ You can run the `make` command inside the Docker container:
 docker run --rm -v $PWD:/home lennartwittkuhn/replaysim-wittkuhn-etal2021 /bin/sh -c "cd /home; make all"
 ```
 
+The figures created by the simulation can be retrieved as Build Artifacts.
+Search the latest executed workflow and Build Artifacts [here](https://github.com/lnnrtwttkhn/replaysim-wittkuhn-etal2021/actions/) to download the figures.
+
 #### Building the container
 
 The commands below were used by us to create the container.

--- a/README.md
+++ b/README.md
@@ -7,3 +7,29 @@ Code for Review illustration in Wittkuhn, Chien, McMaster, Schuck
 ```
 Wittkuhn, L., Chien, S., Hall-McMaster, S., and Schuck, N. W. (2021). *Replay in minds and machines*. Neuroscience & Biobehavioral Reviews, 129:367–388. doi: [10.1016/j.neubiorev.2021.08.002](https://doi.org/10.1016/j.neubiorev.2021.08.002)
 ```
+
+## Build
+
+### Make
+
+```bash
+make all
+```
+
+### Docker
+
+```bash
+docker login
+```
+
+```bash
+docker build -t lennartwittkuhn/replaysim-wittkuhn-etal2021:latest .
+```
+
+```bash
+docker push lennartwittkuhn/replaysim-wittkuhn-etal2021:latest
+```
+
+```bash
+docker run --rm -v $PWD:/home lennartwittkuhn/replaysim-wittkuhn-etal2021 /bin/sh -c "cd /home; make all"
+```


### PR DESCRIPTION
Hi @nschuck,

in order to also ship a common computational environment, I have quickly created a Docker container that can be used to run the simulations.

To make execution of the code from the command line easier, I have also added a Makefile.

Finally, both can be combined to execute the simulation on every push to the repo using GitHub Workflows.

I think that's neat because we provide a common computational environment and the figures produced by the simulation can be retrieved as a Build artifact from the executed workflow (see example [here](https://github.com/lnnrtwttkhn/replaysim-wittkuhn-etal2021/actions/))

**Warning:** I would first merge #2 before merging this one.